### PR TITLE
CI: allow manual run

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,6 +8,7 @@ on:
       - master
   schedule:
     - cron: '0 0 * * 6'
+  workflow_dispatch:
 
 jobs:
   main:


### PR DESCRIPTION
This will help us to deal with cases when the CI has been auto-disabled.