### PR TITLE
CI: migrate to macOS 12

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ${{ matrix.image }}
     strategy:
       matrix:
-        image: [ macos-10.15, ubuntu-20.04, windows-2019 ]
+        image: [ macos-12, ubuntu-20.04, windows-2019 ]
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
macOS 10 has been removed by GitHub, so we no longer can use it.