### PR TITLE
CI: disable fail-fast

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,6 +16,7 @@ jobs:
     strategy:
       matrix:
         image: [ macos-12, ubuntu-20.04, windows-2019 ]
+      fail-fast: false
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
This will allow the builds on non-failing platforms to finish instead of failing all if only one platform fails.

For now this new behavior is preferable for us, because sometimes the tests may be flaky.